### PR TITLE
Debug模式，不拷贝子工程，只做连接

### DIFF
--- a/Script/git/Flutter/build_ios.sh
+++ b/Script/git/Flutter/build_ios.sh
@@ -177,8 +177,12 @@ flutter_copy_packages() {
                 local plugin_path_ios="${plugin_path}ios"
                 if [ -e ${plugin_path_ios} ]; then
                     if [ -s ${plugin_path_ios} ]; then
-                        echo "copy plugin 'plugin_name' from '${plugin_path_ios}' to '${PRODUCT_PATH}/${plugin_name}'"
-                        cp -rf ${plugin_path_ios} "${PRODUCT_PATH}/${plugin_name}"
+						echo "copy plugin 'plugin_name' from '${plugin_path_ios}' to '${PRODUCT_PATH}/${plugin_name}'"
+						if [[ "${BUILD_MODE}" == "release" ]]; then
+							cp -rf ${plugin_path_ios} "${PRODUCT_PATH}/${plugin_name}"
+						else
+							ln -s ${plugin_path_ios} "${PRODUCT_PATH}/${plugin_name}"
+						fi
                     fi
                 fi
             fi

--- a/Script/git/Native/flutterhelper.rb
+++ b/Script/git/Native/flutterhelper.rb
@@ -104,7 +104,7 @@ def install_release_flutter_app_pod(product_path)
             next
         end
 
-        sub_abs_path = File.join(product_path, sub)
+        sub_abs_path = File.realpath(File.join(product_path, sub))
         pod sub, :path=>sub_abs_path
     end
 


### PR DESCRIPTION
常常有这种需要：在Xcocde修改了plugin的代码，如果改的只是副本，又得手动同步去flutter plugin的对应文件。不如debug的时候只做软连接，而不是copy